### PR TITLE
61 add description to round type table

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -6,8 +6,8 @@ class Round < ApplicationRecord
   ROUND_DESCRIPTION = {
     totale_minus: 'Sum of King, Diamonds, Queens and Tricks (each Trick -50)',
     totale_plus: 'Sum of Ten, Diamonds, Queens and Tricks (each Trick +50)',
-    rentz_minus: 'Scores: 0, -400, -800, -1200, ...',
-    rentz_plus: 'Scores: 0, +400, +800, +1200, ...',
+    rentz_minus: 'Scores from last: 0, -400, -800, -1200, ...',
+    rentz_plus: 'Scores from first: 0, +400, +800, +1200, ...',
     king: '-400 for King of Hearts',
     ten: '+400 for Ten of Clubs',
     queens: '-100 each Queen',

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -4,14 +4,14 @@ class Round < ApplicationRecord
   DIAMONDS_VALUE = 50
 
   ROUND_DESCRIPTION = {
-    totale_minus: 'test1',
-    totale_plus: 'test2',
-    rentz_minus: 'test3',
-    rentz_plus: 'test4',
+    totale_minus: 'Sum of King, Diamonds, Queens and Tricks (each Trick -50)',
+    totale_plus: 'Sum of Ten, Diamonds, Queens and Tricks (each Trick +50)',
+    rentz_minus: 'Scores: 0, -400, -800, -1200, ...',
+    rentz_plus: 'Scores: 0, +400, +800, +1200, ...',
     king: '-400 for King of Hearts',
     ten: '+400 for Ten of Clubs',
-    queens: '-100 for every Queen',
-    diamonds: ' -50 for every Diamond'
+    queens: '-100 each Queen',
+    diamonds: ' -50 each Diamond'
   }.freeze
 
   after_initialize :set_default_scores

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -3,6 +3,17 @@ class Round < ApplicationRecord
   QUEENS_VALUE = 100
   DIAMONDS_VALUE = 50
 
+  ROUND_DESCRIPTION = {
+    totale_minus: 'test1',
+    totale_plus: 'test2',
+    rentz_minus: 'test3',
+    rentz_plus: 'test4',
+    king: '-400 for King of Hearts',
+    ten: '+400 for Ten of Clubs',
+    queens: '-100 for every Queen',
+    diamonds: ' -50 for every Diamond'
+  }.freeze
+
   after_initialize :set_default_scores
   before_validation :validate_scores, on: :update
   before_create :set_position

--- a/app/views/shared/_round_type_table.html.erb
+++ b/app/views/shared/_round_type_table.html.erb
@@ -13,7 +13,10 @@
   <tbody>
     <% Round.round_types.each do |round_type_key, round_type_value| %>
       <tr>
-        <td class="border border-dark"><%= round_type_value %></td>
+        <td class="border border-dark">
+          <strong><%= round_type_value %></strong><br/>
+          <span style="font-size: 0.8em;"><%= Round::ROUND_DESCRIPTION[round_type_key.to_sym] %></span>
+        </td>
         <% @game.game_players.each do |game_player| %>
           <% round_played = game_player.rounds.any? { |round| round.round_type == round_type_key } %>
           <td class="border border-dark <%= 'bg-info' if round_played %>"></td>


### PR DESCRIPTION
Fixes https://github.com/robert-damoc/game-stats/issues/61

Implemented descriptions for each round_type on the round_type_table
<img width="1645" alt="image" src="https://github.com/robert-damoc/game-stats/assets/137196597/b060f29e-813d-44e6-a9a5-89071d2b0d4e">
